### PR TITLE
Added map type check for validaterl main module.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 TheProduct.Works
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/validaterl.erl
+++ b/src/validaterl.erl
@@ -22,7 +22,7 @@ validate(Plan) ->
                  end,
                  [ {Name, Value, Spec, validate(Value, Spec)} ||
                      {Name, Value, Spec} <- Plan ]).
-    
+
 
 %% numericality
 validate(undefined, #numericality{
@@ -208,6 +208,8 @@ validate(A, #type{ is = pid }) when is_pid(A) ->
 validate(A, #type{ is = tuple }) when is_tuple(A) ->
     true;
 validate(A, #type{ is = list }) when is_list(A) ->
+    true;
+validate(A, #type{ is = map }) when is_map(A) ->
     true;
 validate(_, #type{}) ->
     false;
@@ -474,9 +476,10 @@ type_test() ->
     ?assert(validate({}, #type{ is = tuple })),
     ?assert(validate([], #type{ is = list })),
     ?assert(validate(true, #type{ is = boolean })),
-    ?assert(validate(false, #type{ is = boolean })).
-    
-    
-    
+    ?assert(validate(false, #type{ is = boolean })),
+    ?assert(validate(#{}, #type{ is = map })).
+
+
+
 
 -endif.


### PR DESCRIPTION
Maps are part of Erlang now, so I've extended the type check to include that too.
